### PR TITLE
Setup code coverage for javascript and haskell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ cabal-dev
 *.hi
 *.chi
 *.chs.h
+.hpc
 .virthualenv
 lib
 docs

--- a/canvashs-client/tests/test.html
+++ b/canvashs-client/tests/test.html
@@ -18,42 +18,101 @@
   <!-- include source files here... -->
   <!--  <script type="text/javascript" src="javascript/file"></script> -->
   <script type="text/javascript" src="../js/jquery.js"></script>
+  <script type="text/javascript" src="../js/mousewheel.js"></script>
   <script type="text/javascript" src="../js/kinetic.js"></script>
-  <script type="text/javascript" src="../js/main.js"></script>
+  <script type="text/javascript" src="../js/main.js" data-cover></script>
   <script type="text/javascript" src="../js/utils.js"></script>
 
+  <!-- Code coverage tools -->
+  <script type="text/javascript" src="../../lib/blanket/dist/qunit/blanket.js"></script>
+  <script type="text/javascript" src="../../lib/blanket/src/adapters/jasmine-blanket.js"></script>
+  <script type="text/javascript" src="../../lib/blanket/test/helpers/console_runner.js"></script>
 
   <script type="text/javascript">
-    (function() {
-      var jasmineEnv = jasmine.getEnv();
-      jasmineEnv.updateInterval = 1000;
+    (function () {
+          var currentWindowOnload = window.onload;
+          window.onload = function() {
+              if (currentWindowOnload) {
+                  currentWindowOnload();
+              }
+              if(typeof jasmine === 'undefined' || typeof blanket === 'undefined') {
+                  document.getElementById("testInstructions").style.display = "block";
+              }
+              try {
+              _blanket.utils.getFile(
+                _blanket.utils.qualifyURL("../js/main.js"),
+                function() {}, 
+                function(){
+                }
+              );
 
-      var trivialReporter = new jasmine.TrivialReporter();
-
-      jasmineEnv.addReporter(trivialReporter);
-
-      jasmineEnv.specFilter = function(spec) {
-        return trivialReporter.specFilter(spec);
-      };
-
-      var currentWindowOnload = window.onload;
-
-      window.onload = function() {
-        if (currentWindowOnload) {
-          currentWindowOnload();
-        }
-        execJasmine();
-      };
-
-      function execJasmine() {
-        jasmineEnv.execute();
-      }
+              } catch(e) {
+                // Show instructions how to use code coverage
+                $("#codeCoverageInstructions").css('display',"block");
+                $("body").addClass('hideBlanket');
+              }
+          
+          };
+          window.blanketTestJasmineExpected=1;
+          
+          var jasmineEnv = jasmine.getEnv();
+          jasmineEnv.updateInterval = 1000;
+          
+          var trivialReporter = new jasmine.TrivialReporter();
+          
+          jasmineEnv.addReporter(trivialReporter);
+          
+          jasmineEnv.specFilter = function(spec) {
+              return trivialReporter.specFilter(spec);
+          };
+          
+          /* this is just for our automated tests */
+          window.jasmine_phantom_reporter = new jasmine.ConsoleReporter;
+          
+          jasmineEnv.addReporter(jasmine_phantom_reporter);
+          /*   */
+          
+          jasmineEnv.specFilter = function (spec) {
+              return trivialReporter.specFilter(spec);
+          };
+          
+          
+          function execJasmine() {
+              jasmineEnv.execute();
+          }
 
     })();
   </script>
 
+  <style>
+    body {
+      margin: 0px;
+    }
+    #TrivialReporter {
+      position: relative;
+    }
+    #testInstructions, #codeCoverageInstructions {
+      padding: 20px;
+      display: none;
+    }
+    .hideBlanket #blanket-main {
+      display: none;
+    }
+  </style>
+
 </head>
 
 <body>
+  <div id="testInstructions">
+    To run tests and see code coverage you first have to install the required libraries. This can be done using either "runhaskell tests/SetupTests.hs" or "cabal install --enable-tests & cabal test" in the root of the Canvas.hs project.
+  </div>
+  <div id="codeCoverageInstructions">
+    Code coverage is disabled. To enable:<br />
+    <ul>
+      <li><strong>Chrome:</strong> Run chrome using: chrome.exe --disable-web-security</li>
+      <li><strong>Firefox:</strong> Follow these instructions: <a href="http://kb.mozillazine.org/Links_to_local_pages_do_not_work">Links to local pages do not work</a>.</li>
+      <li><strong>Other:</strong> Enable cross origin requests in your browser.</li>
+    </ul>
+  </div>
 </body>
 </html>

--- a/canvashs-client/tests/test.html
+++ b/canvashs-client/tests/test.html
@@ -105,12 +105,12 @@
 
 <body>
   <div id="testInstructions">
-    To run tests and see code coverage you first have to install the required libraries. This can be done using either "runhaskell tests/SetupTests.hs" or "cabal install --enable-tests & cabal test" in the root of the Canvas.hs project.
+    To run tests and see code coverage you first have to install the required libraries. This can be done using either "<em>runhaskell tests/SetupTests.hs</em>" or "<em>cabal install --enable-tests & cabal test</em>" in the root of the Canvas.hs project.
   </div>
   <div id="codeCoverageInstructions">
     Code coverage is disabled. To enable:<br />
     <ul>
-      <li><strong>Chrome:</strong> Run chrome using: chrome.exe --disable-web-security</li>
+      <li><strong>Chrome:</strong> Run chrome using: (Mac) "<em>open /Applications/Google\ Chrome.app --args --disable-web-security</em>" (Windows) "<em>chrome.exe --disable-web-security</em>"</li>
       <li><strong>Firefox:</strong> Follow these instructions: <a href="http://kb.mozillazine.org/Links_to_local_pages_do_not_work">Links to local pages do not work</a>.</li>
       <li><strong>Other:</strong> Enable cross origin requests in your browser.</li>
     </ul>

--- a/canvashs-client/tests/test.html
+++ b/canvashs-client/tests/test.html
@@ -87,6 +87,7 @@
   <style>
     body {
       margin: 0px;
+      background: #FFFFFF;
     }
     #TrivialReporter {
       position: relative;

--- a/canvashs.cabal
+++ b/canvashs.cabal
@@ -9,7 +9,8 @@ data-files:          canvashs-client/*.html,
                      canvashs-client/js/*.js,
                      canvashs-client/js/*.map,
                      canvashs-client/css/*.css
-
+flag hpc
+  default: False
 Library
   build-depends: 	base >= 4,
                   QuickCheck >= 2.4,
@@ -37,6 +38,8 @@ Library
                   CanvasHs.Protocol
                   CanvasHs.Protocol.Input
                   CanvasHs.Protocol.Output
+  if flag(hpc)
+    ghc-options: -fhpc
 
 Test-Suite setup-tests
   type:            exitcode-stdio-1.0
@@ -44,7 +47,6 @@ Test-Suite setup-tests
   build-depends:   
                    base >= 4 && < 5,
                    process >= 1.1
-
 
 Test-Suite javascript-tests
   type:            exitcode-stdio-1.0

--- a/tests/SetupTests.hs
+++ b/tests/SetupTests.hs
@@ -10,6 +10,7 @@ cloneRepos
        executeShellCommand "git -v"
        executeShellCommand "git clone https://github.com/pivotal/jasmine.git lib/jasmine -b v1.3.1"
        executeShellCommand "git clone https://github.com/HumbleSoftware/js-imagediff.git lib/js-imagediff -b v1.0.4"
+       executeShellCommand "git clone https://github.com/alex-seville/blanket.git lib/blanket"
        putStrLn "Finished test install script"
 
 executeShellCommand cmd   = putStrLn ("EXEC: " ++ cmd) >> system cmd >>= check


### PR DESCRIPTION
Code coverage tools are setup for haskell and javascript.

Open `canvashs-client/tests/test.html` for javascript code coverage.

Run `cabal install --enable-library-coverage --enable-tests` to generate code coverage reports. Code coverage reports will be generated in `dist\hpc\html\module-test`.
