### PR TITLE
Exposed Colors module to end user

### DIFF
--- a/canvashs.cabal
+++ b/canvashs.cabal
@@ -34,7 +34,7 @@ Library
                   suspend >= 0.1.0.2,
                   filepath
 
-  Exposed-modules:	CanvasHs, CanvasHs.Data
+  Exposed-modules:	CanvasHs, CanvasHs.Data, CanvasHs.Colors
   hs-source-dirs:	canvashs-module
   other-modules:  Paths_canvashs,
                   CanvasHs.Launch,


### PR DESCRIPTION
I want to have this merged to dev, but that requires me to make a pull request, here it is :D.

The fix is trivial, it only exposes CanvasHs.Colors in the cabal file
